### PR TITLE
Config fixes; Connection handling

### DIFF
--- a/source_pubsub/client.go
+++ b/source_pubsub/client.go
@@ -383,6 +383,10 @@ func (c *PubSubClient) startCDC(ctx context.Context, topic Topic) error {
 				return fmt.Errorf("error recv events: %w", err)
 			}
 
+			if len(events) == 0 {
+				continue
+			}
+
 			sdk.Logger(ctx).Debug().
 				Int("events", len(events)).
 				Dur("elapsed", time.Since(lastRecvdAt)).
@@ -590,6 +594,11 @@ func (c *PubSubClient) Recv(ctx context.Context, topic string, replayID []byte) 
 			return nil, nil
 		}
 		return nil, err
+	}
+
+	// Empty response
+	if len(resp.Events) == 0 {
+		return []ConnectResponseEvent{}, nil
 	}
 
 	logger.Info().

--- a/source_pubsub/config.go
+++ b/source_pubsub/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	TopicName string `json:"topicName"`
 
 	// TopicNames are the TopicNames the source connector will subscribe to
-	TopicNames []string `json:"topicNames" validate:"required"`
+	TopicNames []string `json:"topicNames"`
 
 	// Deprecated: Username is the client secret from the salesforce app.
 	Username string `json:"username"`
@@ -92,7 +92,7 @@ func (c Config) Validate(ctx context.Context) (Config, error) {
 	}
 
 	if len(c.TopicNames) == 0 {
-		errs = append(errs, fmt.Errorf("invalid TopicName name %q", c.TopicNames))
+		errs = append(errs, fmt.Errorf("'topicNames' empty, need at least one topic"))
 	}
 
 	if c.PollingPeriod == 0 {

--- a/source_pubsub/source.go
+++ b/source_pubsub/source.go
@@ -50,23 +50,23 @@ func (s *Source) Parameters() config.Parameters {
 }
 
 func (s *Source) Configure(ctx context.Context, cfg config.Config) error {
-	var config Config
+	var c Config
 
 	if err := sdk.Util.ParseConfig(
 		ctx,
 		cfg,
-		&s.config,
+		&c,
 		NewSource().Parameters(),
 	); err != nil {
 		return fmt.Errorf("failed to parse config: %w", err)
 	}
 
-	config, err := config.Validate(ctx)
+	c, err := c.Validate(ctx)
 	if err != nil {
 		return fmt.Errorf("config failed to validate: %w", err)
 	}
 
-	s.config = config
+	s.config = c
 
 	return nil
 }


### PR DESCRIPTION
### Description

Make `topicNames` config setting to be not required. Validate and error when empty. Add gRPC trailer logging.

Move the timer in the `startCDC` go routine and use a cancel contex to signal finish. Ensure the pubsub client is done once all recv has completed.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-salesforce/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
